### PR TITLE
fix audio sample list

### DIFF
--- a/TrackEditor/EditAudioWidget.cpp
+++ b/TrackEditor/EditAudioWidget.cpp
@@ -18,8 +18,9 @@ public:
   CEditAudioWidgetPrivate() {};
   ~CEditAudioWidgetPrivate() {};
 
-  QString audioAy[119] = {
-    "<none>"   ,//ENGINE in sound.ini, appears to mean none in track data
+  QString audioAy[120] = {
+    "<none>"   ,
+    "ENGINE"   ,
     "ENGINE2"  ,
     "BIGCRASH" ,
     "SKID1"    ,


### PR DESCRIPTION
Samples are off by one e.g. Tsunami Twister has TOOFAST and RECORD instead of TOOSLOW and TOOFAST