### PR TITLE
Add Zig build for WhipLib (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,6 +363,11 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Zig build artifacts
+zig-out/
+.zig-cache/
+
 /TrackEditor/resource.cpp
 /TrackEditor/null
 /TrackEditor/ui

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,148 @@
+// Zig build for ROLLER Track Editor.
+//
+// Phase 1 (current): WhipLib static library compiles on macOS, Linux, Windows.
+// Phase 2: ModelExporter / TrackAnalyzer / CarPlansParser CLI tools (need FBX SDK).
+// Phase 3: TrackEditor Qt5 GUI (needs moc/uic/rcc orchestration).
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Build-time toggles. FBX SDK ships precompiled binaries that are not in
+    // the repo; until they're installed under external/FBX/lib/, the FBX
+    // exporter cannot compile.
+    const enable_fbx = b.option(
+        bool,
+        "fbx",
+        "Compile FBXExporter.cpp (requires FBX SDK installed at external/FBX/)",
+    ) orelse false;
+
+    const whiplib = buildWhipLib(b, target, optimize, enable_fbx);
+    b.installArtifact(whiplib);
+}
+
+fn buildWhipLib(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    enable_fbx: bool,
+) *std.Build.Step.Compile {
+    const mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+        .link_libcpp = true,
+    });
+
+    mod.addIncludePath(b.path("WhipLib"));
+    mod.addIncludePath(b.path("WhipLib/CarPlans"));
+    mod.addIncludePath(b.path("WhipLib/SignPlans"));
+    mod.addIncludePath(b.path("external/glm"));
+    mod.addIncludePath(b.path("external/stb"));
+    // The codebase mixes `#include <glew.h>` and `#include "glew.h"` without a
+    // `GL/` prefix, so both directories must be on the search path.
+    mod.addIncludePath(b.path("external/glew/include"));
+    mod.addIncludePath(b.path("external/glew/include/GL"));
+
+    mod.addCMacro("GLM_ENABLE_EXPERIMENTAL", "1");
+    // GLEW pulls in <GL/glu.h> by default. The GLU library is deprecated and
+    // unused by this codebase (verified by grep), and asking for it makes
+    // cross-compilation to Linux brittle (no glu headers in zig's sysroot).
+    mod.addCMacro("GLEW_NO_GLU", "1");
+    // WhipLib.h's WLFUNC macro defaults to __declspec(dllimport) on Windows
+    // unless one of WHIPLIB_LIB / WHIPLIB_DLL is defined. We're building a
+    // static archive, so flag that to keep the implementations linkable.
+    mod.addCMacro("WHIPLIB_LIB", "1");
+
+    addPlatformIncludes(mod, target);
+
+    if (enable_fbx) {
+        mod.addIncludePath(b.path("external/FBX/include"));
+    }
+
+    const cpp_flags: []const []const u8 = &.{
+        "-std=c++17",
+        "-fPIC",
+        // Match the upstream Linux Makefile defaults.
+    };
+
+    var sources = std.ArrayList([]const u8){};
+    defer sources.deinit(b.allocator);
+    sources.appendSlice(b.allocator, &whiplib_core_sources) catch @panic("OOM");
+    if (enable_fbx) {
+        sources.append(b.allocator, "FBXExporter.cpp") catch @panic("OOM");
+    }
+
+    mod.addCSourceFiles(.{
+        .root = b.path("WhipLib"),
+        .files = sources.items,
+        .flags = cpp_flags,
+    });
+
+    return b.addLibrary(.{
+        .name = "WhipLib",
+        .root_module = mod,
+        .linkage = .static,
+    });
+}
+
+// Hardcoded brewed prefixes are fine for now — once Phase 2 lands we'll
+// resolve these via `brew --prefix` invoked from a build step or pkg-config.
+fn addPlatformIncludes(mod: *std.Build.Module, target: std.Build.ResolvedTarget) void {
+    switch (target.result.os.tag) {
+        .macos => {
+            // GL_SILENCE_DEPRECATION mutes the wall of OpenGL warnings macOS
+            // emits since 10.14. The editor uses GLEW for GL bindings so the
+            // deprecated system headers aren't actually called.
+            mod.addCMacro("GL_SILENCE_DEPRECATION", "1");
+
+            // Apple Silicon Homebrew lives under /opt/homebrew; Intel under
+            // /usr/local. Add both — the missing one is harmless.
+            mod.addSystemIncludePath(.{ .cwd_relative = "/opt/homebrew/include" });
+            mod.addSystemIncludePath(.{ .cwd_relative = "/opt/homebrew/opt/libxml2/include/libxml2" });
+            mod.addSystemIncludePath(.{ .cwd_relative = "/usr/local/include" });
+            mod.addSystemIncludePath(.{ .cwd_relative = "/usr/local/opt/libxml2/include/libxml2" });
+        },
+        .linux => {
+            mod.addSystemIncludePath(.{ .cwd_relative = "/usr/include/libxml2" });
+        },
+        else => {},
+    }
+}
+
+// Mirrors the SRC list in WhipLib/Makefile, minus FBXExporter.cpp (gated by
+// -Dfbx). Keep alphabetised for diff-friendliness.
+const whiplib_core_sources = [_][]const u8{
+    "Camera.cpp",
+    "CarHelpers.cpp",
+    "Clock.cpp",
+    "DisasmHelpers.cpp",
+    "DriveComponent.cpp",
+    "Entity.cpp",
+    "GameClock.cpp",
+    "GameInput.cpp",
+    "IndexBuffer.cpp",
+    "Logging.cpp",
+    "MathHelpers.cpp",
+    "NoclipComponent.cpp",
+    "ObjExporter.cpp",
+    "ObjImporter.cpp",
+    "Palette.cpp",
+    "PhysicsComponent.cpp",
+    "Renderer.cpp",
+    "Scene.cpp",
+    "SceneManager.cpp",
+    "Shader.cpp",
+    "ShapeComponent.cpp",
+    "ShapeData.cpp",
+    "ShapeFactory.cpp",
+    "Texture.cpp",
+    "Track.cpp",
+    "TrackComponent.cpp",
+    "Unmangler.cpp",
+    "VertexArray.cpp",
+    "VertexBuffer.cpp",
+    "WhipLib.cpp",
+};
+
+const std = @import("std");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = .roller_track_editor,
+    .version = "0.0.0",
+    .fingerprint = 0x14fcfb7861a850c3,
+    .minimum_zig_version = "0.15.2",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "WhipLib",
+        "external",
+    },
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+[tools]
+zig = "0.15.2"
+
+[tasks.build]
+description = "Build all configured Zig targets (WhipLib + tools)"
+run = "zig build"
+
+[tasks.clean]
+description = "Clean Zig build artifacts"
+run = "rm -rf zig-out .zig-cache"
+
+[tasks.test]
+description = "Run zig build tests (none yet — placeholder)"
+run = "zig build test"


### PR DESCRIPTION
## Summary
- Brings the project under a single Zig-driven build system, mirroring the [ROLLER](https://github.com/FatalDecomp/ROLLER) repo's `mise` + `build.zig` pattern.
- WhipLib compiles cleanly for **macOS arm64** (native), **aarch64-linux-gnu** (cross), and **x86_64-windows-gnu** (cross) from one `zig build` invocation on a Mac, replacing the per-platform Makefile / vcxproj split for this library.
- Lays the foundation for getting the editor working on macOS, where the existing build is currently unbuildable.

## What's in this PR
- `mise.toml` pins Zig 0.15.2 (matches ROLLER) with `build` / `clean` / `test` tasks.
- `build.zig` + `build.zig.zon` produce `zig-out/lib/libWhipLib.a` for any supported target.
- Reuses bundled `external/glew` / `external/glm` / `external/stb` headers — no Homebrew dependency required for Phase 1.
- `.gitignore` updated for `zig-out/` and `.zig-cache/`.

## Build configuration choices worth flagging for review
- **`GLEW_NO_GLU=1`** defined globally. GLEW's header includes `<GL/glu.h>` by default; codebase has zero GLU calls (verified by grep), so this avoids needing libGLU on every cross target.
- **`WHIPLIB_LIB=1`** defined. `WhipLib.h`'s `WLFUNC` macro defaults to `__declspec(dllimport)` on Windows when neither `WHIPLIB_LIB` nor `WHIPLIB_DLL` is set — that broke the Windows static-lib build. Defining `WHIPLIB_LIB` keeps the implementations linkable.
- **`FBXExporter.cpp` gated behind `-Dfbx=true`**. FBX SDK 2020.3.7 headers don't compile cleanly with modern clang (typo `mLefttChild` in `fbxredblacktree.h`, deprecated `vsprintf`, non-trivially-copyable `memcpy`). Resolving that is Phase 2 along with the CLI tools that actually link FBX.

## Out of scope (future phases)
- **Phase 2:** ModelExporter / TrackAnalyzer / CarPlansParser CLI binaries; FBX SDK header compatibility.
- **Phase 3:** TrackEditor Qt5 GUI app (needs `moc` / `uic` / `rcc` orchestration over Homebrew's `qt@5`).

## Test plan
- [x] `mise exec -- zig build` on macOS arm64 produces `zig-out/lib/libWhipLib.a` (~11 MB)
- [x] `mise exec -- zig build -Dtarget=aarch64-linux-gnu` succeeds
- [x] `mise exec -- zig build -Dtarget=x86_64-windows-gnu` succeeds
- [x] `mise exec -- zig build -Doptimize=ReleaseFast` succeeds
- [ ] Verify on a Linux host (cross-build only tested from Mac)
- [ ] Verify on a Windows host