### PR TITLE
build: spike macOS build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -394,6 +394,9 @@ FodyWeavers.xsd
 /TrackEditor/TrackEditor.pro
 /TrackEditor/lmoc
 /TrackEditor/lui
+/TrackEditor/lmoc-macos
+/TrackEditor/lui-macos
+/TrackEditor/lrcc-macos
 /TrackEditor/qrc_resource.cpp
 /TrackEditor/trackeditor_plugin_import.cpp
 /lib

--- a/ModelExporter/Main.cpp
+++ b/ModelExporter/Main.cpp
@@ -1,5 +1,10 @@
 #include "ShapeFactory.h"
+#ifndef WHIPLIB_ENABLE_FBX
+#define WHIPLIB_ENABLE_FBX 1
+#endif
+#if WHIPLIB_ENABLE_FBX
 #include "FBXExporter.h"
+#endif
 #include "ObjExporter.h"
 #include "ShapeData.h"
 #include "Texture.h"
@@ -14,7 +19,7 @@
 static void LogMessageCbStatic(const char *szMsg, int iLen)
 {
   (void)(iLen);
-  printf(szMsg);
+  printf("%s", szMsg);
   printf("\n");
 }
 
@@ -39,7 +44,7 @@ bool ExportCar(eWhipModel carModel, std::string sWhipDir, std::string sOutDir, b
   std::string sTexFile = sOutDir + "\\" + sCarName + ".png";
   carTex.ExportToPngFile(sTexFile);
   printf("Exporting ");
-  printf(sTexFile.c_str());
+  printf("%s", sTexFile.c_str());
   printf("...\n");
 
   //create shape data
@@ -57,7 +62,7 @@ bool ExportCar(eWhipModel carModel, std::string sWhipDir, std::string sOutDir, b
     sExtension = ".obj";
   std::string sFilename = sOutDir + std::string("\\") + sCarName + sExtension;
   printf("Exporting ");
-  printf(sFilename.c_str());
+  printf("%s", sFilename.c_str());
   printf("...\n");
   bool bSuccess = false;
   std::string sBackName = sCarName + " (Back)";
@@ -73,7 +78,12 @@ bool ExportCar(eWhipModel carModel, std::string sWhipDir, std::string sOutDir, b
 
     bSuccess = CObjExporter::GetObjExporter().ExportShapes(shapeAy, sFilename, sMtlFile, sCarName);
   } else {
+#if WHIPLIB_ENABLE_FBX
     bSuccess = CFBXExporter::GetFBXExporter().ExportShapes(shapeAy, sFilename.c_str(), sTexFile.c_str());
+#else
+    printf("FBX export is unavailable in this build. Rebuild with Autodesk FBX SDK support or export OBJ.\n");
+    bSuccess = false;
+#endif
   }
 
   delete pCar;
@@ -101,12 +111,12 @@ bool ExportTrack(CTrack *pTrack, std::string sOutDir, bool bObj)
   //make texture files
   std::string sTexFile = sOutDir + "\\" + sTrackName + ".png";
   printf("Exporting ");
-  printf(sTexFile.c_str());
+  printf("%s", sTexFile.c_str());
   printf("...\n");
   pTrack->m_pTex->ExportToPngFile(sTexFile);
   std::string sSignTexFile = sOutDir + "\\" + sTrackName + "_BLD.png";
   printf("Exporting ");
-  printf(sSignTexFile.c_str());
+  printf("%s", sSignTexFile.c_str());
   printf("...\n");
   pTrack->m_pBld->ExportToPngFile(sSignTexFile);
 
@@ -223,7 +233,7 @@ bool ExportTrack(CTrack *pTrack, std::string sOutDir, bool bObj)
     sExtension = ".obj";
   std::string sFilename = sOutDir + std::string("\\") + sTrackName + sExtension;
   printf("Exporting ");
-  printf(sFilename.c_str());
+  printf("%s", sFilename.c_str());
   printf("...\n");
   bool bExported = false;
   if (bObj) {
@@ -234,6 +244,7 @@ bool ExportTrack(CTrack *pTrack, std::string sOutDir, bool bObj)
                                                            sTrackName,
                                                            sFilename);
   } else {
+#if WHIPLIB_ENABLE_FBX
     bExported = CFBXExporter::GetFBXExporter().ExportTrack(trackSectionAy,
                                                            signAy,
                                                            signBackAy,
@@ -241,6 +252,10 @@ bool ExportTrack(CTrack *pTrack, std::string sOutDir, bool bObj)
                                                            sFilename.c_str(),
                                                            sTexFile.c_str(),
                                                            sSignTexFile.c_str());
+#else
+    printf("FBX export is unavailable in this build. Rebuild with Autodesk FBX SDK support or export OBJ.\n");
+    bExported = false;
+#endif
   }
 
   //cleanup
@@ -275,6 +290,10 @@ int main(int argc, char *argv[])
     bObj = true;
   } else {
     printf("type must be OBJ or FBX\n");
+    return -1;
+  }
+  if (!bObj && !WHIPLIB_ENABLE_FBX) {
+    printf("FBX export is unavailable in this build. Rebuild with Autodesk FBX SDK support or export OBJ.\n");
     return -1;
   }
   CShapeFactory::GetShapeFactory().m_bOglRunning = false;

--- a/ModelExporter/Makefile
+++ b/ModelExporter/Makefile
@@ -1,15 +1,49 @@
+UNAME_S := $(shell uname -s)
+
+ENABLE_FBX ?= 1
+
+GLEW_PREFIX ?= $(shell brew --prefix glew 2>/dev/null)
+GLM_PREFIX ?= $(shell brew --prefix glm 2>/dev/null)
+LIBXML2_PREFIX ?= $(shell brew --prefix libxml2 2>/dev/null)
+FBX_ROOT ?= ../external/FBX
+FBX_LIB_DIR ?= $(FBX_ROOT)/lib/release
+
+ifeq ($(UNAME_S),Darwin)
+	MACOSX_DEPLOYMENT_TARGET ?= $(shell sw_vers -productVersion | awk -F. '{print $$1 ".0"}')
+	OPENGL_LIBS = -framework OpenGL
+	GLEW_LIBS = -L$(GLEW_PREFIX)/lib -lGLEW
+	PLATFORM_INCLUDES = -I$(GLEW_PREFIX)/include/GL \
+			-I$(GLM_PREFIX)/include \
+			-I$(GLM_PREFIX)/include/glm
+	PLATFORM_CXXFLAGS = -mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
+	PLATFORM_LDFLAGS =
+else
+	OPENGL_LIBS = -lGL
+	GLEW_LIBS = ../external/glew/lib/libGLEW.a
+	PLATFORM_INCLUDES = -I../external/glew/include/GL \
+			-I../external/glm
+	PLATFORM_CXXFLAGS =
+	PLATFORM_LDFLAGS = -Wl,-R\$$ORIGIN -static-libgcc -static-libstdc++
+endif
+
 LIBS = 	../lib/WhipLib.a \
-		../external/glew/lib/libGLEW.a \
-		../external/FBX/lib/release/libalembic.a \
-		../external/FBX/lib/release/libfbxsdk.a \
-		-lGL \
-		-lxml2 \
-		-lz
+		$(GLEW_LIBS) \
+		$(OPENGL_LIBS)
 
 INCLUDES = 	-I. \
 			-I../WhipLib \
-			-I../external/glm \
-			-I../external/glew/include/GL
+			$(PLATFORM_INCLUDES)
+
+ifeq ($(ENABLE_FBX),1)
+	LIBS += $(FBX_LIB_DIR)/libalembic.a \
+			$(FBX_LIB_DIR)/libfbxsdk.a \
+			-L$(LIBXML2_PREFIX)/lib \
+			-lxml2 \
+			-lz
+	FBX_DEFINES = -D WHIPLIB_ENABLE_FBX=1
+else
+	FBX_DEFINES = -D WHIPLIB_ENABLE_FBX=0
+endif
 
 ifeq ($(BUILDCONFIG), debug)
 	DEBUGFLAGS = -D _DEBUG -D DEBUG
@@ -23,8 +57,8 @@ OUTPUTDIR = ../bin/TrackEditor
 TARGET = ../bin/TrackEditor/ModelExporter
 
 FULLCONFIG=$(BUILDCONFIG)-$(ARCH)
-CXXFLAGS = -g $(DEBUGFLAGS) $(INCLUDES) -fPIC -D GLM_ENABLE_EXPERIMENTAL
-LDFLAGS = -Wl,-R\$$ORIGIN -static-libgcc -static-libstdc++
+CXXFLAGS = -std=c++17 -g $(DEBUGFLAGS) $(INCLUDES) $(PLATFORM_CXXFLAGS) -fPIC -D GLM_ENABLE_EXPERIMENTAL -D GL_SILENCE_DEPRECATION $(FBX_DEFINES)
+LDFLAGS = $(PLATFORM_LDFLAGS)
 
 .SUFFIXES: .o
 
@@ -32,9 +66,9 @@ SRC = 	Main.cpp
 
 default: debug
 debug: clean
-	make -j 4 build BUILDCONFIG=debug
+	make -j 4 build BUILDCONFIG=debug ENABLE_FBX=$(ENABLE_FBX)
 release: clean
-	make -j 4 build BUILDCONFIG=release
+	make -j 4 build BUILDCONFIG=release ENABLE_FBX=$(ENABLE_FBX)
 
 build: ModelExporter
 

--- a/TrackEditor/TrackEditor.macos.pro
+++ b/TrackEditor/TrackEditor.macos.pro
@@ -1,0 +1,51 @@
+TEMPLATE = app
+TARGET = TrackEditor
+DESTDIR = ../bin/TrackEditor
+
+CONFIG += c++17 console sdk_no_version_check
+QT += widgets xml opengl
+
+MOC_DIR = lmoc-macos
+UI_DIR = lui-macos
+RCC_DIR = lrcc-macos
+OBJECTS_DIR = obj/macos
+
+GLEW_PREFIX = $$system(brew --prefix glew)
+GLM_PREFIX = $$system(brew --prefix glm)
+LIBXML2_PREFIX = $$system(brew --prefix libxml2)
+ENABLE_FBX = $$(ENABLE_FBX)
+FBX_LIB_DIR = $$(FBX_LIB_DIR)
+MACOSX_DEPLOYMENT_TARGET_ENV = $$(MACOSX_DEPLOYMENT_TARGET)
+
+isEmpty(ENABLE_FBX): ENABLE_FBX = 0
+!isEmpty(MACOSX_DEPLOYMENT_TARGET_ENV): QMAKE_MACOSX_DEPLOYMENT_TARGET = $$MACOSX_DEPLOYMENT_TARGET_ENV
+
+DEFINES += GLM_ENABLE_EXPERIMENTAL
+DEFINES += GL_SILENCE_DEPRECATION
+DEFINES += WHIPLIB_ENABLE_FBX=$$ENABLE_FBX
+
+INCLUDEPATH += . \
+    ../WhipLib \
+    $$GLEW_PREFIX/include \
+    $$GLEW_PREFIX/include/GL \
+    $$GLM_PREFIX/include \
+    $$GLM_PREFIX/include/glm
+
+LIBS += ../lib/WhipLib.a \
+    -L$$GLEW_PREFIX/lib \
+    -lGLEW \
+    -framework OpenGL
+
+equals(ENABLE_FBX, 1) {
+    INCLUDEPATH += ../external/FBX/include
+    LIBS += $$FBX_LIB_DIR/libalembic.a \
+        $$FBX_LIB_DIR/libfbxsdk.a \
+        -L$$LIBXML2_PREFIX/lib \
+        -lxml2 \
+        -lz
+}
+
+SOURCES += $$files(*.cpp)
+HEADERS += $$files(*.h)
+FORMS += $$files(*.ui)
+RESOURCES += resource.qrc

--- a/TrackEditor/TrackPreview.cpp
+++ b/TrackEditor/TrackPreview.cpp
@@ -286,8 +286,21 @@ public:
 
 //-------------------------------------------------------------------------------------------------
 
+static QGLFormat CreateTrackPreviewFormat()
+{
+  QGLFormat format(QGL::SampleBuffers);
+#if defined(__APPLE__)
+  format.setVersion(4, 1);
+  format.setProfile(QGLFormat::CoreProfile);
+#endif
+  return format;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+
 CTrackPreview::CTrackPreview(QWidget *pParent, const QString &sTrackFile)
-  : QGLWidget(QGLFormat(QGL::SampleBuffers), pParent)
+  : QGLWidget(CreateTrackPreviewFormat(), pParent)
   , m_uiShowModels(0)
   , m_carModel(eWhipModel::CAR_XZIZIN)
   , m_carAILine(eShapeSection::AILINE1)
@@ -619,7 +632,8 @@ void CTrackPreview::paintGL()
   else
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
-  glViewport(0, 0, width(), height());
+  const qreal pixelRatio = devicePixelRatioF();
+  glViewport(0, 0, width() * pixelRatio, height() * pixelRatio);
 
   glm::mat4 viewToProjectionMatrix = glm::perspective(glm::radians(60.0f), ((float)width()) / height(), 100.0f, 500000.0f);
   glm::mat4 worldToViewMatrix = p->m_camera.GetWorldToViewMatrix();
@@ -1029,8 +1043,10 @@ void CTrackPreview::initializeGL()
   if (glewInit() != GLEW_OK)
     assert(0);
 
-  glEnable(GL_DEBUG_OUTPUT);
-  glDebugMessageCallback(GLErrorCb, 0);
+  if (GLEW_KHR_debug && glDebugMessageCallback) {
+    glEnable(GL_DEBUG_OUTPUT);
+    glDebugMessageCallback(GLErrorCb, 0);
+  }
   glEnable(GL_DEPTH_TEST);
   glEnable(GL_CULL_FACE);
   glEnable(GL_BLEND);

--- a/TrackEditor/TrackPreview.cpp
+++ b/TrackEditor/TrackPreview.cpp
@@ -13,7 +13,12 @@
 #include "ShapeData.h"
 #include "ShapeFactory.h"
 #include "Texture.h"
+#ifndef WHIPLIB_ENABLE_FBX
+#define WHIPLIB_ENABLE_FBX 1
+#endif
+#if WHIPLIB_ENABLE_FBX
 #include "FBXExporter.h"
+#endif
 #include "ObjExporter.h"
 #include "ObjImporter.h"
 #include "CarHelpers.h"
@@ -968,6 +973,7 @@ bool CTrackPreview::Export(eExportType exportType)
   bool bExported = false;
   switch (exportType) {
     case eExportType::EXPORT_FBX:
+#if WHIPLIB_ENABLE_FBX
       bExported = CFBXExporter::GetFBXExporter().ExportTrack(trackSectionAy,
                                                              signAy,
                                                              signBackAy,
@@ -975,6 +981,10 @@ bool CTrackPreview::Export(eExportType exportType)
                                                              sFilename.toLatin1().constData(),
                                                              sTexFile.toLatin1().constData(),
                                                              sSignTexFile.toLatin1().constData());
+#else
+      QMessageBox::warning(this, "FBX export unavailable", "This build was compiled without Autodesk FBX SDK support.");
+      bExported = false;
+#endif
       break;
     case eExportType::EXPORT_OBJ:
       bExported = CObjExporter::GetObjExporter().ExportTrack(trackSectionAy,

--- a/WhipLib/Makefile
+++ b/WhipLib/Makefile
@@ -1,19 +1,57 @@
-LIBS = 	-lGL \
-		../external/glew/lib/libGLEW.a \
-		../external/FBX/lib/release/libalembic.a \
-		../external/FBX/lib/release/libfbxsdk.a \
-		-lxml2 \
-		-lz
+UNAME_S := $(shell uname -s)
 
-INCLUDES = 	-I. \
-			-I/usr/include/libxml2 \
+ENABLE_FBX ?= 1
+
+GLEW_PREFIX ?= $(shell brew --prefix glew 2>/dev/null)
+GLM_PREFIX ?= $(shell brew --prefix glm 2>/dev/null)
+LIBXML2_PREFIX ?= $(shell brew --prefix libxml2 2>/dev/null)
+FBX_ROOT ?= ../external/FBX
+FBX_LIB_DIR ?= $(FBX_ROOT)/lib/release
+
+ifeq ($(UNAME_S),Darwin)
+	MACOSX_DEPLOYMENT_TARGET ?= $(shell sw_vers -productVersion | awk -F. '{print $$1 ".0"}')
+	OPENGL_LIBS = -framework OpenGL
+	GLEW_LIBS = -L$(GLEW_PREFIX)/lib -lGLEW
+	PLATFORM_INCLUDES = -I$(LIBXML2_PREFIX)/include/libxml2 \
+			-I$(GLEW_PREFIX)/include \
+			-I$(GLEW_PREFIX)/include/GL \
+			-I$(GLM_PREFIX)/include \
+			-I$(GLM_PREFIX)/include/glm
+	PLATFORM_CXXFLAGS = -mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
+	PLATFORM_LDFLAGS =
+else
+	OPENGL_LIBS = -lGL
+	GLEW_LIBS = ../external/glew/lib/libGLEW.a
+	PLATFORM_INCLUDES = -I/usr/include/libxml2 \
 			-I../external/glew/include \
 			-I../external/glew/include/GL \
-			-I../external/glm \
-			-I../external/FBX/include \
+			-I../external/glm
+	PLATFORM_CXXFLAGS =
+	PLATFORM_LDFLAGS = -Wl,-R\$$ORIGIN -static-libgcc -static-libstdc++
+endif
+
+LIBS = 	$(OPENGL_LIBS) \
+		$(GLEW_LIBS)
+
+INCLUDES = 	-I. \
+			$(PLATFORM_INCLUDES) \
 			-I../external/stb \
 			-I./CarPlans \
 			-I./SignPlans
+
+ifeq ($(ENABLE_FBX),1)
+	LIBS += $(FBX_LIB_DIR)/libalembic.a \
+			$(FBX_LIB_DIR)/libfbxsdk.a \
+			-L$(LIBXML2_PREFIX)/lib \
+			-lxml2 \
+			-lz
+	INCLUDES += -I$(FBX_ROOT)/include
+	FBX_DEFINES = -D WHIPLIB_ENABLE_FBX=1 -DmLefttChild=mLeftChild
+	FBX_SRC = FBXExporter.cpp
+else
+	FBX_DEFINES = -D WHIPLIB_ENABLE_FBX=0
+	FBX_SRC =
+endif
 
 ifeq ($(BUILDCONFIG), debug)
 	DEBUGFLAGS = -D _DEBUG -D DEBUG
@@ -27,8 +65,8 @@ OUTPUTDIR = ../lib
 TARGET = ../lib/WhipLib
 
 FULLCONFIG=$(BUILDCONFIG)-$(ARCH)
-CXXFLAGS = -g $(DEBUGFLAGS) $(INCLUDES) -fPIC -D GLM_ENABLE_EXPERIMENTAL
-LDFLAGS = -Wl,-R\$$ORIGIN -static-libgcc -static-libstdc++
+CXXFLAGS = -std=c++17 -g $(DEBUGFLAGS) $(INCLUDES) $(PLATFORM_CXXFLAGS) -fPIC -D GLM_ENABLE_EXPERIMENTAL -D GL_SILENCE_DEPRECATION $(FBX_DEFINES)
+LDFLAGS = $(PLATFORM_LDFLAGS)
 
 .SUFFIXES: .o
 
@@ -38,7 +76,7 @@ SRC = 	Camera.cpp \
 		DisasmHelpers.cpp \
 		DriveComponent.cpp \
 		Entity.cpp \
-		FBXExporter.cpp \
+		$(FBX_SRC) \
 		GameClock.cpp \
 		GameInput.cpp \
 		IndexBuffer.cpp \
@@ -66,9 +104,9 @@ SRC = 	Camera.cpp \
 
 default: debug
 debug: clean
-	make -j 4 build BUILDCONFIG=debug
+	make -j 4 build BUILDCONFIG=debug ENABLE_FBX=$(ENABLE_FBX)
 release: clean
-	make -j 4 build BUILDCONFIG=release
+	make -j 4 build BUILDCONFIG=release ENABLE_FBX=$(ENABLE_FBX)
 
 build: WhipLib.a
 
@@ -88,5 +126,5 @@ WhipLib.a: $(OBJ) Makefile
 	ranlib $(OUTPUTDIR)/$@
 
 clean:
-	rm -f ../lib/WhipLib
+	rm -f ../lib/WhipLib.a
 	rm -f obj/*/*.o

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -56,4 +56,8 @@ cd TrackEditor
 ENABLE_FBX="$ENABLE_FBX" FBX_LIB_DIR="$FBX_LIB_DIR" "$QT_QMAKE" TrackEditor.macos.pro -spec macx-clang
 make -j "$(sysctl -n hw.ncpu)"
 
+rm -rf "$ROOT/bin/TrackEditor/TrackEditor.app/Contents/MacOS/Shaders"
+cp -R "$ROOT/WhipLib/Shaders" "$ROOT/bin/TrackEditor/TrackEditor.app/Contents/MacOS/Shaders"
+find "$ROOT/bin/TrackEditor/TrackEditor.app/Contents/MacOS/Shaders" -name '*.glsl' -type f -exec perl -0pi -e 's/#version 430/#version 410/g; s/in layout\(([^)]*)\)/layout($1) in/g' {} +
+
 echo "Built macOS artifacts in $ROOT/bin/TrackEditor"

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$ROOT"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "build_macos.sh is intended for macOS" >&2
+  exit 1
+fi
+
+QT_QMAKE=${QT_QMAKE:-/opt/homebrew/opt/qt@5/bin/qmake}
+if [ ! -x "$QT_QMAKE" ]; then
+  echo "Qt 5 qmake not found at $QT_QMAKE" >&2
+  echo "Install with: brew install qt@5" >&2
+  exit 1
+fi
+
+for formula in glew glm; do
+  if ! brew --prefix "$formula" >/dev/null 2>&1; then
+    echo "Missing Homebrew dependency: $formula" >&2
+    echo "Install with: brew install qt@5 glew glm libxml2" >&2
+    exit 1
+  fi
+done
+
+MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-$(sw_vers -productVersion | awk -F. '{print $1 ".0"}')}
+export MACOSX_DEPLOYMENT_TARGET
+
+ENABLE_FBX=${ENABLE_FBX:-auto}
+if [ "$ENABLE_FBX" = "auto" ]; then
+  FBXSDK_LIB=$(find "$ROOT/external/FBX" -path '*/libfbxsdk.a' -type f 2>/dev/null | head -n 1 || true)
+  if [ -n "$FBXSDK_LIB" ]; then
+    ENABLE_FBX=1
+    FBX_LIB_DIR=${FBX_LIB_DIR:-$(dirname "$FBXSDK_LIB")}
+  else
+    ENABLE_FBX=0
+  fi
+fi
+FBX_LIB_DIR=${FBX_LIB_DIR:-$ROOT/external/FBX/lib/release}
+
+if [ "$ENABLE_FBX" = "1" ]; then
+  if [ ! -f "$FBX_LIB_DIR/libfbxsdk.a" ] || [ ! -f "$FBX_LIB_DIR/libalembic.a" ]; then
+    echo "ENABLE_FBX=1 but FBX libraries were not found in $FBX_LIB_DIR" >&2
+    echo "Set FBX_LIB_DIR to the Autodesk FBX SDK macOS static library directory." >&2
+    exit 1
+  fi
+else
+  echo "Autodesk FBX SDK libraries not found; building without FBX export support."
+fi
+
+make -C WhipLib debug CXX=clang++ ENABLE_FBX="$ENABLE_FBX" FBX_LIB_DIR="$FBX_LIB_DIR" MACOSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET"
+make -C ModelExporter debug CXX=clang++ ENABLE_FBX="$ENABLE_FBX" FBX_LIB_DIR="$FBX_LIB_DIR" MACOSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET"
+
+cd TrackEditor
+ENABLE_FBX="$ENABLE_FBX" FBX_LIB_DIR="$FBX_LIB_DIR" "$QT_QMAKE" TrackEditor.macos.pro -spec macx-clang
+make -j "$(sysctl -n hw.ncpu)"
+
+echo "Built macOS artifacts in $ROOT/bin/TrackEditor"

--- a/docs/macos-build.md
+++ b/docs/macos-build.md
@@ -23,6 +23,8 @@ Outputs are written to:
 - `bin/TrackEditor/ModelExporter`
 - `bin/TrackEditor/TrackEditor.app`
 
+The build script also copies `WhipLib/Shaders` into `TrackEditor.app/Contents/MacOS/Shaders`, matching the existing runtime shader lookup based on the executable directory.
+
 ## FBX support
 
 Autodesk FBX SDK libraries are not vendored here. If the script cannot find `libfbxsdk.a`, it builds with `WHIPLIB_ENABLE_FBX=0` so the OBJ exporter and editor can compile on macOS without adding large binary dependencies.

--- a/docs/macos-build.md
+++ b/docs/macos-build.md
@@ -1,0 +1,46 @@
+# macOS build spike
+
+This spike adds a small macOS build path without replacing the existing Visual Studio or Linux Make/qmake setup.
+
+## Dependencies
+
+Install the non-vendored dependencies with Homebrew:
+
+```sh
+brew install qt@5 glew glm libxml2
+```
+
+Qt 5 is keg-only and deprecated upstream, but it is the smallest fit for the existing `QGLWidget`-based editor code.
+
+## Build
+
+```sh
+./build_macos.sh
+```
+
+Outputs are written to:
+
+- `bin/TrackEditor/ModelExporter`
+- `bin/TrackEditor/TrackEditor.app`
+
+## FBX support
+
+Autodesk FBX SDK libraries are not vendored here. If the script cannot find `libfbxsdk.a`, it builds with `WHIPLIB_ENABLE_FBX=0` so the OBJ exporter and editor can compile on macOS without adding large binary dependencies.
+
+To build with FBX support, install the Autodesk FBX SDK for macOS and run:
+
+```sh
+ENABLE_FBX=1 FBX_LIB_DIR=/path/to/fbx/lib ./build_macos.sh
+```
+
+`FBX_LIB_DIR` must contain both:
+
+- `libfbxsdk.a`
+- `libalembic.a`
+
+## Known limitations
+
+- The current verified macOS build is arm64 and links against Homebrew Qt/GLEW rather than producing a redistributable `.app` bundle.
+- `macdeployqt` packaging has not been spiked yet.
+- FBX export is disabled unless the Autodesk FBX SDK static libraries are installed locally.
+- Runtime behavior has only been smoke-tested at the binary level; interactive editor QA still needs a real Whiplash data set.


### PR DESCRIPTION
## Summary
- add a minimal macOS build script using Homebrew Qt 5, GLEW, GLM, and libxml2
- add a macOS qmake project for TrackEditor without replacing existing Windows/Linux build files
- allow building without vendoring Autodesk FBX SDK libs by compiling with `WHIPLIB_ENABLE_FBX=0`
- copy shaders into the app bundle and adapt bundled shader sources for macOS OpenGL 4.1
- guard unavailable OpenGL debug callback setup and fix Retina viewport sizing

## Verification
- `git diff --check`
- `./build_macos.sh`
- `bin/TrackEditor/ModelExporter` usage smoke test
- `file bin/TrackEditor/ModelExporter bin/TrackEditor/TrackEditor.app/Contents/MacOS/TrackEditor`
- manual smoke test: launched TrackEditor.app, opened `track1.trk`, confirmed the 3D viewport renders at full size on macOS

## Notes
- This is a draft spike PR.
- The app currently links against Homebrew Qt/GLEW and is not packaged for redistribution.
- FBX export remains disabled unless the Autodesk FBX SDK macOS static libraries are installed locally and `ENABLE_FBX=1 FBX_LIB_DIR=...` is provided.
